### PR TITLE
TEST: assert 'Partners' instead of 'Sponsors'

### DIFF
--- a/tests/Feature/ComponentsTest.php
+++ b/tests/Feature/ComponentsTest.php
@@ -16,7 +16,7 @@ class ComponentsTest extends TestCase
         $view->assertSee('PHP Tek 2026', false);
         $view->assertSee('About', false);
         $view->assertSee('Venue', false);
-        $view->assertSee('Sponsors', false);
+        $view->assertSee('Partners', false);
         $view->assertSee('Register', false);
     }
 


### PR DESCRIPTION
- references of Sponsors are being changed to Partners, this updates the test to assert the new term