### PR TITLE
Update sponsors description to match production

### DIFF
--- a/database/migrations/2025_07_23_030528_create_sponsors_table.php
+++ b/database/migrations/2025_07_23_030528_create_sponsors_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
                 $table->string('website');
                 $table->string('slug')->unique();
                 $table->string('logo')->nullable();
-                $table->string('description')->nullable();
+                $table->text('description')->nullable();
                 $table->json('socials')->nullable();
                 $table->timestamps();
             });


### PR DESCRIPTION
Also resolves the `artisan db:seed` command throwing errors attempting to put too much info in the `description` field.