### PR TITLE
Fix partners link in footer

### DIFF
--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -96,7 +96,7 @@
                     <li><a href="#venue"
                            class="text-gray-600 dark:text-slate-300 hover:text-tek-blue-700 dark:hover:text-tek-blue-400 transition-colors">Venue</a>
                     </li>
-                    <li><a href="#sponsors"
+                    <li><a href="#partners"
                            class="text-gray-600 dark:text-slate-300 hover:text-tek-blue-700 dark:hover:text-tek-blue-400 transition-colors">Partners</a>
                     </li>
                     <li><a href="#register"


### PR DESCRIPTION
This follows up #23 and fixes the link for "Partners" in the footer so it scrolls to the partner section.

<img width="990" height="508" alt="image" src="https://github.com/user-attachments/assets/c0888d64-095e-41e7-b2c6-4c1e7453005e" />

(I'm opening this blindly and didn't actually pull it down to test it)