### PR TITLE
Update timezone for countdown timer

### DIFF
--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -73,6 +73,22 @@ class Conference extends Model
     }
 
     /**
+     * Get the start date as an absolute ISO 8601 instant, interpreting the
+     * stored wall-clock time as the conference timezone (e.g. America/Chicago).
+     */
+    public function getStartInstantIso(): ?string
+    {
+        if (! $this->start_date) {
+            return null;
+        }
+
+        return $this->start_date
+            ->copy()
+            ->shiftTimezone(config('tek.conference.timezone'))
+            ->toIso8601String();
+    }
+
+    /**
      * Get the formatted start date.
      */
     public function formattedStartDate(string $format = 'Y-m-d'): ?string

--- a/resources/views/components/hero-section.blade.php
+++ b/resources/views/components/hero-section.blade.php
@@ -21,7 +21,7 @@
                     opportunities with the PHP community.
                 </p>
                 @if($conference && $conference->getStartDate())
-                    <div x-data="countdown('{{ $conference->getStartDate()->toIso8601String() }}')"
+                    <div x-data="countdown('{{ $conference->getStartInstantIso() }}')"
                          class="bg-white/80 dark:bg-tek-blue-900/30 backdrop-blur-sm border border-tek-blue-200 dark:border-tek-blue-800 rounded-xl p-4 md:p-6 shadow-md max-w-xl"
                          role="timer"
                          aria-live="polite"

--- a/tests/Feature/ConferenceModelTest.php
+++ b/tests/Feature/ConferenceModelTest.php
@@ -68,6 +68,25 @@ class ConferenceModelTest extends TestCase
     }
 
     /**
+     * The start instant ISO string should be expressed against the configured
+     * conference timezone (Central time), not the application's UTC default.
+     */
+    public function test_start_instant_iso_uses_conference_timezone(): void
+    {
+        config()->set('tek.conference.timezone', 'America/Chicago');
+
+        $conference = Conference::create([
+            'uuid' => 'test-uuid-instant',
+            'name' => 'Instant Conference',
+            'start_date' => '2026-05-19 09:00:00',
+            'end_date' => '2026-05-21 17:00:00',
+        ]);
+
+        // 9:00 AM Central in May (CDT, UTC-5) is 14:00 UTC.
+        $this->assertEquals('2026-05-19T09:00:00-05:00', $conference->getStartInstantIso());
+    }
+
+    /**
      * Test the formatted date range method.
      */
     public function test_formatted_date_range(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved countdown timer accuracy by ensuring it displays the conference start time using the configured conference timezone instead of the application's default timezone.

* **Tests**
  * Added comprehensive test coverage to verify proper timezone handling when formatting the conference start instant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/phparch/phptek-2026/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->